### PR TITLE
Wrong use of -join parameter of pd

### DIFF
--- a/op-guide/binary-deployment.md
+++ b/op-guide/binary-deployment.md
@@ -277,7 +277,6 @@ mysql -h 192.168.199.113 -P 4000 -u root -D test
                 --client-urls="http://192.168.199.114:2379" \
                 --peer-urls="http://192.168.199.114:2380" \
                 --initial-cluster="pd1=http://192.168.199.113:2380,pd2=http://192.168.199.114:2380,pd3=http://192.168.199.115:2380" \
-                --join="http://192.168.199.113:2379" \
                 -L "info" \
                 --log-file=pd.log
 
@@ -286,7 +285,6 @@ mysql -h 192.168.199.113 -P 4000 -u root -D test
                 --client-urls="http://192.168.199.115:2379" \
                 --peer-urls="http://192.168.199.115:2380" \
                 --initial-cluster="pd1=http://192.168.199.113:2380,pd2=http://192.168.199.114:2380,pd3=http://192.168.199.115:2380" \
-                --join="http://192.168.199.113:2379" \
                 -L "info" \
                 --log-file=pd.log
 ```


### PR DESCRIPTION
When I use pd-sever to create a pd cluster, parameters -initial-cluster and -join will conflict.
There are two ways to modify, remove directly.
Displayed error：
FATA[0000] parse cmd flags error: -initial-cluster and -join can not be provided at the same time
